### PR TITLE
RollManager function-based service skeleton and tests, to be implemented by Al

### DIFF
--- a/Frontend/src/Global.spec.js
+++ b/Frontend/src/Global.spec.js
@@ -1,0 +1,19 @@
+import { range, uniq } from "lodash";
+import { getRandom } from "./Global";
+
+describe("getRandom()", () => {
+  it("returns a random value from 0 to 5", () => {
+    const res = getRandom();
+    expect(res).toBeGreaterThanOrEqual(0);
+    expect(res).toBeLessThanOrEqual(5);
+  });
+  it("returns a random value", () => {
+    // in order to check that we don't always get the same number, let's try this 10,000 times and check that we don't always get the same result
+    const results = [];
+    range(10_000).forEach(() => {
+      results.push(getRandom());
+    });
+
+    expect(uniq(results).length).toBeGreaterThan(1);
+  });
+});

--- a/Frontend/src/Services/roll-manager/README.md
+++ b/Frontend/src/Services/roll-manager/README.md
@@ -1,0 +1,32 @@
+# Roll Manager service
+
+This is a service to manage the dice rolls, similar to what was accomplished with `Roll.js`
+
+## Note: JSDOC for types
+
+we are going to use JSDoc here to infer and describe types instead of using typescript. See:
+- <https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html>
+- <https://jsdoc.app/tags-typedef.html>
+
+With this we can have autocomplete support in our editors, as well as some in-editor warnings if we pass the wrong data
+
+## Structure of the service
+
+This service will not be a class, but instead we will expose different functions that will either query the data, or transform the data.
+
+Since these files use JSDOC, which makes for a lot of lines of code, the different functions are separated into different files.
+
+## Files
+
+Here are the files that contain the public functions and error classes, to be used by the rest of the app. 
+
+- [`creation.js`](./creation.js): contains the functions to create a new Data object, one with a blank state and another based on a given state
+- [`queries.js`](./queries.js): contains the functions that answers questions about the state of the data
+- [`actions.js`](./actions.js): contains the functions that respond to user actions. If they have any effect on the data, they will return a new object, so that react knows that something has changed
+- [`errors.js`](./errors.js): contains the different error classes that we may throw
+
+We also have other files with utilities and validations that are to be used only by the Roll Manager service
+
+- [`private/validations.js`](private/validations.js): contains the functions that throw exceptions with invalid state, settings, or data.
+- [`private/typedefs.js`](private/typedefs.js): contains the JSDoc with the type definitions of the different objects (data, state, settings, etc)
+- [`private/test-utils.js`](private/test-utils.js): contains some functions to simplify our test suite regarding valid sate, settings and data, as well as to check that the public functions do the appropriate validations

--- a/Frontend/src/Services/roll-manager/__tests__/actions.spec.js
+++ b/Frontend/src/Services/roll-manager/__tests__/actions.spec.js
@@ -1,0 +1,232 @@
+import {
+  testValidatesData,
+  VALID_SETTINGS,
+  VALID_STATE_UNROLLED,
+  VALID_STATE_ROLLED,
+  testValidatesDieIndex,
+  testValidatesRolledDie,
+} from "../private/test-utils";
+import { rollDice, selectDie, toggleDie, unselectDie } from "../actions";
+import { cloneDeep, range, uniq } from "lodash";
+import { NoRollsLeftError } from "../errors";
+
+describe("toggleDie(data, dieIndex)", () => {
+  testValidatesData((data) => toggleDie(data, 0));
+  testValidatesDieIndex((data, index) => toggleDie(data, index));
+  testValidatesRolledDie((data, index) => toggleDie(data, index));
+
+  it("with a selected die -> returns a new data object with the same settings and a clone of the state, with that die unselected", () => {
+    const state = cloneDeep(VALID_STATE_ROLLED);
+    state.dice[0].isSelected = true;
+    const data = { settings: VALID_SETTINGS, state };
+
+    const expectedState = cloneDeep(VALID_STATE_ROLLED);
+    expectedState.dice[0].isSelected = false;
+    const expected = { settings: data.settings, state: expectedState };
+
+    const res = toggleDie(data, 0);
+    expect(res).toStrictEqual(expected);
+    expect(res).not.toBe(data);
+    expect(res.settings).toBe(data.settings);
+    expect(res.state.dice[0]).not.toBe(data.state.dice[0]);
+    expect(res.state.dice[1]).toBe(data.state.dice[1]);
+    expect(res.state.dice[2]).toBe(data.state.dice[2]);
+  });
+
+  it("with a unselected die -> returns a new data object with the same settings and a clone of the state, with that die selected", () => {
+    const state = cloneDeep(VALID_STATE_ROLLED);
+    state.dice[0].isSelected = false;
+    const data = { settings: VALID_SETTINGS, state };
+
+    const expectedState = cloneDeep(VALID_STATE_ROLLED);
+    expectedState.dice[0].isSelected = true;
+    const expected = { settings: data.settings, state: expectedState };
+
+    const res = toggleDie(data, 0);
+    expect(res).toStrictEqual(expected);
+    expect(res).not.toBe(data);
+    expect(res.settings).toBe(data.settings);
+    expect(res.state.dice[0]).not.toBe(data.state.dice[0]);
+    expect(res.state.dice[1]).toBe(data.state.dice[1]);
+    expect(res.state.dice[2]).toBe(data.state.dice[2]);
+  });
+});
+
+describe("unselectDie(data, dieIndex)", () => {
+  testValidatesData((data) => unselectDie(data, 0));
+  testValidatesDieIndex((data, index) => unselectDie(data, index));
+  testValidatesRolledDie((data, index) => unselectDie(data, index));
+
+  it("with a selected die -> returns a new data object with the same settings and a clone of the state, with that die unselected", () => {
+    const state = cloneDeep(VALID_STATE_ROLLED);
+    state.dice[0].isSelected = true;
+    const data = { settings: VALID_SETTINGS, state };
+
+    const expectedState = cloneDeep(VALID_STATE_ROLLED);
+    expectedState.dice[0].isSelected = false;
+    const expected = { settings: data.settings, state: expectedState };
+
+    const res = unselectDie(data, 0);
+    expect(res).toStrictEqual(expected);
+    expect(res).not.toBe(data);
+    expect(res.settings).toBe(data.settings);
+    expect(res.state.dice[0]).not.toBe(data.state.dice[0]);
+    expect(res.state.dice[1]).toBe(data.state.dice[1]);
+    expect(res.state.dice[2]).toBe(data.state.dice[2]);
+  });
+
+  it("with a unselected die -> returns the same data unchanged", () => {
+    const state = cloneDeep(VALID_STATE_ROLLED);
+    state.dice[0].isSelected = false;
+    const data = { settings: VALID_SETTINGS, state };
+    const cloneForTest = cloneDeep(data);
+
+    const res = unselectDie(data, 0);
+    expect(res).toBe(data);
+    expect(res).toEqual(cloneForTest); // we check that we haven't mutated data
+  });
+});
+
+describe("selectDie(data, dieIndex)", () => {
+  testValidatesData((data) => selectDie(data, 0));
+  testValidatesDieIndex((data, index) => selectDie(data, index));
+  testValidatesRolledDie((data, index) => selectDie(data, index));
+
+  it("with a unselected die -> returns a new data object with the same settings and a clone of the state, with that die unselected", () => {
+    const state = cloneDeep(VALID_STATE_ROLLED);
+    state.dice[0].isSelected = false;
+    const data = { settings: VALID_SETTINGS, state };
+
+    const expectedState = cloneDeep(VALID_STATE_ROLLED);
+    expectedState.dice[0].isSelected = true;
+    const expected = { settings: data.settings, state: expectedState };
+
+    const res = selectDie(data, 0);
+    expect(res).toStrictEqual(expected);
+    expect(res).not.toBe(data);
+    expect(res.settings).toBe(data.settings);
+    expect(res.state.dice[0]).not.toBe(data.state.dice[0]);
+    expect(res.state.dice[1]).toBe(data.state.dice[1]);
+    expect(res.state.dice[2]).toBe(data.state.dice[2]);
+  });
+
+  it("with a unselected die -> returns the same data unchanged", () => {
+    const state = cloneDeep(VALID_STATE_ROLLED);
+    state.dice[0].isSelected = true;
+    const data = { settings: VALID_SETTINGS, state };
+    const cloneForTest = cloneDeep(data);
+
+    const res = selectDie(data, 0);
+    expect(res).toBe(data);
+    expect(res).toEqual(cloneForTest); // we check that we haven't mutated data
+  });
+});
+
+describe("rollDice(data)", () => {
+  testValidatesData((data) => rollDice(data, 0));
+
+  it("explodes with not enough rolls left", () => {
+    const state = cloneDeep(VALID_STATE_ROLLED);
+    state.numberOfRolls = VALID_SETTINGS.diceRollLimit;
+    const data = { settings: VALID_SETTINGS, state };
+    expect(() => rollDice(data)).toThrow(NoRollsLeftError);
+  });
+
+  it("works with enough rolls left", () => {
+    const state = cloneDeep(VALID_STATE_ROLLED);
+    state.numberOfRolls = VALID_SETTINGS.diceRollLimit - 1;
+    const data = { settings: VALID_SETTINGS, state };
+    expect(() => rollDice(data)).not.toThrow(NoRollsLeftError);
+  });
+
+  it("works with unrolled", () => {
+    const state = cloneDeep(VALID_STATE_UNROLLED);
+    const data = { settings: VALID_SETTINGS, state };
+    expect(() => rollDice(data)).not.toThrow(NoRollsLeftError);
+  });
+
+  it("will return a copy of the data, with the same settings and a different object for state", () => {
+    const state = cloneDeep(VALID_STATE_UNROLLED);
+    const data = { settings: VALID_SETTINGS, state };
+
+    const res = rollDice(data);
+    expect(res).not.toBe(data);
+    expect(res.settings).toBe(data.settings);
+    expect(res.state).not.toBe(data.state);
+  });
+
+  it("the returned state will have numberOfRolls + 1", () => {
+    const state = cloneDeep(VALID_STATE_UNROLLED);
+    const data = { settings: VALID_SETTINGS, state };
+
+    const res = rollDice(data);
+    expect(res.state.numberOfRolls).toEqual(state.numberOfRolls + 1);
+  });
+
+  it("the returned state will have a new array of dice of the same length", () => {
+    const state = cloneDeep(VALID_STATE_UNROLLED);
+    const data = { settings: VALID_SETTINGS, state };
+
+    const res = rollDice(data);
+    expect(res.state.dice.length).toEqual(state.dice.length);
+    expect(res.state.dice).not.toBe(state.dice);
+  });
+
+  describe("selected dice", () => {
+    it("with the all the dice selected, returns the same data", () => {
+      const state = cloneDeep(VALID_STATE_ROLLED);
+      state.dice = state.dice.map((d) => ({
+        value: d.value,
+        isSelected: true,
+      }));
+      const data = { settings: VALID_SETTINGS, state };
+      const cloneForTest = cloneDeep(data);
+
+      const res = rollDice(data);
+      expect(res).toBe(data);
+      expect(res).toEqual(cloneForTest); // we check that we haven't mutated data
+    });
+
+    it("with the some the dice selected, returns the a new array. The elements of the selected dice will be the same object, while the unselected ones will be a new object", () => {
+      const state = cloneDeep(VALID_STATE_ROLLED);
+      state.dice[1].isSelected = true;
+      state.dice[2].isSelected = true;
+      const data = { settings: VALID_SETTINGS, state };
+
+      const res = rollDice(data);
+      expect(res).not.toBe(data);
+      expect(res.state.dice).not.toBe(data.state.dice);
+      expect(res.state.dice[0]).not.toBe(data.state.dice[0]);
+      expect(res.state.dice[1]).toBe(data.state.dice[1]);
+      expect(res.state.dice[2]).toBe(data.state.dice[2]);
+      expect(res.state.dice[3]).not.toBe(data.state.dice[3]);
+    });
+
+    it("rolls the unselected dice", () => {
+      // to test that we are actually rolling the dice, let's run this 10,000 times and check that we don't always get the same number
+      const state = cloneDeep(VALID_STATE_ROLLED);
+      // all dice selected except the first one
+      state.dice = state.dice.map((d) => ({
+        value: d.value,
+        isSelected: true,
+      }));
+      state.dice[0].isSelected = false;
+      const data = { settings: VALID_SETTINGS, state };
+
+      const originalValueUnselected = state.dice[0].value;
+      const originalValueSelected = state.dice[1].value;
+
+      const unselectedValues = [];
+      const selectedValues = [];
+
+      range(10_000).forEach(() => {
+        const res = rollDice(data);
+        unselectedValues.push(res.state.dice[0].value);
+        selectedValues.push(res.state.dice[1].value);
+      });
+
+      expect(uniq(selectedValues)).toEqual([originalValueSelected]);
+      expect(uniq(unselectedValues).length).toBeGreaterThan(1);
+    });
+  });
+});

--- a/Frontend/src/Services/roll-manager/__tests__/creation.spec.js
+++ b/Frontend/src/Services/roll-manager/__tests__/creation.spec.js
@@ -1,0 +1,69 @@
+import {
+  validateRollManagerData,
+  validateSettings,
+} from "../private/validations";
+import {
+  testValidatesSettings,
+  testValidatesState,
+  VALID_SETTINGS,
+  VALID_STATE_UNROLLED,
+} from "../private/test-utils";
+import { buildRollManagerFresh, buildRollManagerFrom } from "../creation";
+import { isPlainObject } from "lodash";
+import { isValidRollManagerData } from "../queries";
+
+describe("buildRollManagerFresh(settings)", () => {
+  // we can share some specs code by extracting it into functions
+  testValidatesSettings((settings) => buildRollManagerFresh(settings));
+
+  it("returns a new object with given settings and blank state", () => {
+    const settings = {
+      numberOfDice: 6,
+      numberOfExtraDice: 2,
+      diceRollLimit: 3,
+    };
+    const res = buildRollManagerFresh(settings);
+    expect(isPlainObject(res)).toBeTruthy();
+
+    // validateRollManagerData() is already tested, so we can use it here to avoid duplicating a lot of the effort.
+    // it has an extra benefit: if we change the rules of what it means to be valid, we should not have to adapt all the creation tests, or it would be way too much effort.
+    validateRollManagerData(res);
+
+    expect(res.settings).toBe(settings);
+    expect(res.state).toStrictEqual({
+      numberOfRolls: 0,
+      dice: [
+        { isSelected: false, value: -1 },
+        { isSelected: false, value: -1 },
+        { isSelected: false, value: -1 },
+        { isSelected: false, value: -1 },
+        { isSelected: false, value: -1 },
+        { isSelected: false, value: -1 },
+      ],
+    });
+  });
+});
+
+describe("buildRollManagerFrom(settings)", () => {
+  testValidatesSettings((settings) =>
+    buildRollManagerFrom({ settings, state: VALID_STATE_UNROLLED })
+  );
+  testValidatesState((state) =>
+    buildRollManagerFrom({ settings: VALID_SETTINGS, state })
+  );
+
+  it("returns a new object with given settings and a deep-clone of the given state", () => {
+    const settings = VALID_SETTINGS;
+    const state = VALID_STATE_UNROLLED;
+    const res = buildRollManagerFrom({ settings, state });
+    expect(isPlainObject(res)).toBeTruthy();
+
+    // validateRollManagerData() is already tested, so we can use it here to avoid duplicating a lot of the effort.
+    // it has an extra benefit: if we change the rules of what it means to be valid, we should not have to adapt all the creation tests, or it would be way too much effort.
+    validateRollManagerData(res);
+
+    expect(res.settings).toBe(settings);
+    expect(res.state).toStrictEqual(state);
+    expect(res.state).not.toBe(state);
+  });
+});

--- a/Frontend/src/Services/roll-manager/__tests__/queries.spec.js
+++ b/Frontend/src/Services/roll-manager/__tests__/queries.spec.js
@@ -1,0 +1,73 @@
+import { rollManagerHasResults, rollManagerHasRollsLeft } from "../queries";
+import {
+  testValidatesData,
+  VALID_SETTINGS,
+  VALID_STATE_UNROLLED,
+  VALID_STATE_ROLLED,
+} from "../private/test-utils";
+
+describe("rollManagerHasRollsLeft(data)", () => {
+  testValidatesData((data) => rollManagerHasRollsLeft(data));
+  const settings = VALID_SETTINGS;
+
+  it("returns true with number of rolls === 0", () => {
+    const state = {
+      ...VALID_STATE_UNROLLED,
+      numberOfRolls: 0,
+    };
+    expect(rollManagerHasRollsLeft({ settings, state })).toBe(true);
+  });
+
+  it("returns true with number of rolls > 0 and < than the settings", () => {
+    const state = {
+      ...VALID_STATE_ROLLED,
+      numberOfRolls: settings.diceRollLimit - 1,
+    };
+    expect(rollManagerHasRollsLeft({ settings, state })).toBe(true);
+  });
+
+  it("returns false with number of rolls === settings.diceRollLimit", () => {
+    const state = {
+      ...VALID_STATE_ROLLED,
+      numberOfRolls: settings.diceRollLimit,
+    };
+    expect(rollManagerHasRollsLeft({ settings, state })).toBe(false);
+  });
+});
+
+describe("rollManagerHasResults(data)", () => {
+  testValidatesData((data) => rollManagerHasResults(data));
+  const settings = VALID_SETTINGS;
+
+  it("returns false with number of rolls === 0", () => {
+    const state = {
+      ...VALID_STATE_UNROLLED,
+      numberOfRolls: 0,
+    };
+    expect(rollManagerHasResults({ settings, state })).toBe(false);
+  });
+
+  it("returns true with number of rolls === 1", () => {
+    const state = {
+      ...VALID_STATE_ROLLED,
+      numberOfRolls: 1,
+    };
+    expect(rollManagerHasResults({ settings, state })).toBe(true);
+  });
+
+  it("returns true with number of rolls > 0 and < than the settings", () => {
+    const state = {
+      ...VALID_STATE_ROLLED,
+      numberOfRolls: settings.diceRollLimit - 1,
+    };
+    expect(rollManagerHasResults({ settings, state })).toBe(true);
+  });
+
+  it("returns true with number of rolls === settings.diceRollLimit", () => {
+    const state = {
+      ...VALID_STATE_ROLLED,
+      numberOfRolls: settings.diceRollLimit,
+    };
+    expect(rollManagerHasResults({ settings, state })).toBe(true);
+  });
+});

--- a/Frontend/src/Services/roll-manager/actions.js
+++ b/Frontend/src/Services/roll-manager/actions.js
@@ -1,0 +1,69 @@
+import {
+  validateDieIndex,
+  validateRolledDie,
+  validateRollManagerData,
+} from "./private/validations";
+
+/**
+ * after validating the data and dieIndex, as well as that the relevant die has been rolled at least once,
+ * it returns a new data object with the same settings and a clone of the state, with the value of `isSelected` of
+ * the relevant die flipped, and the rest of the dice are the same objects
+ *
+ * @param {RollManagerData} data
+ * @param {number} dieIndex
+ * @return {RollManagerData}
+ */
+export function toggleDie(data, dieIndex) {
+  validateRollManagerData(data);
+  validateDieIndex(data, dieIndex);
+  validateRolledDie(data, dieIndex);
+  // TODO: toggle die
+}
+
+/**
+ * after validating the data and dieIndex, as well as that the relevant die has been rolled at least once,
+ * - if the relevant die is selected, it returns the same data object
+ * - otherwise, it returns a new data object with the same settings
+ *   and a clone of the state, with the value of `isSelected` of the relevant die is false.
+ *   and the rest of the dice are the same objects
+ *
+ * @param {RollManagerData} data
+ * @param {number} dieIndex
+ * @return {RollManagerData}
+ */
+export function selectDie(data, dieIndex) {
+  validateRollManagerData(data);
+  validateDieIndex(data, dieIndex);
+  validateRolledDie(data, dieIndex);
+  // TODO: select die
+}
+
+/**
+ * after validating the data and dieIndex, as well as that the relevant die has been rolled at least once,
+ * - if the relevant die is unselected, it returns the same data object
+ * - otherwise, it returns a new data object with the same settings
+ *   and a clone of the state, with the value of `isSelected` of the relevant die is true.
+ *   and the rest of the dice are the same objects
+ *
+ * @param {RollManagerData} data
+ * @param {number} dieIndex
+ * @return {RollManagerData}
+ */
+export function unselectDie(data, dieIndex) {
+  validateRollManagerData(data);
+  validateDieIndex(data, dieIndex);
+  validateRolledDie(data, dieIndex);
+  // TODO: unselect die
+}
+
+/**
+ *
+ * @param {RollManagerData} data
+ * @return {RollManagerData}
+ */
+export function rollDice(data) {
+  validateRollManagerData(data);
+
+  // TODO: throw if no rolls left
+  // TODO: roll dice
+}

--- a/Frontend/src/Services/roll-manager/creation.js
+++ b/Frontend/src/Services/roll-manager/creation.js
@@ -1,0 +1,51 @@
+import { cloneDeep, isPlainObject, range } from "lodash";
+import { InvalidRollManagerDataError } from "./errors";
+import { validateSettings, validateState } from "./private/validations";
+
+/**
+ * returns a new object with the given settings and a new fresh state: set numberOfRolls = 0 and dice with a new array of unrolled dice
+ *
+ * @param {RollManagerSettings} settings
+ * @return {RollManagerData}
+ */
+export function buildRollManagerFresh(settings) {
+  validateSettings(settings);
+  /**
+   * @type {DieState[]}
+   */
+  const dice = range(settings.numberOfDice).map(() => buildDieState());
+  return { settings, state: { dice, numberOfRolls: 0 } };
+}
+
+/**
+ * returns a new object with the same data with the same settings and a deep-clone of the given state
+ *
+ * @param {RollManagerData} data
+ * @return {RollManagerData}
+ */
+export function buildRollManagerFrom(data) {
+  if (!isPlainObject(data)) {
+    throw new InvalidRollManagerDataError(
+      "The given data param is not a plain object"
+    );
+  }
+
+  validateSettings(data.settings);
+  validateState(data.state);
+  return { settings: data.settings, state: cloneDeep(data.state) };
+}
+
+/**
+ * builds a default DieState
+ * @return {DieState}
+ */
+export function buildDieState() {
+  return { value: DEFAULT_UNROLLED_DIE_VALUE, isSelected: false };
+}
+
+/**
+ * determines the value of the die that indicates that it has not been rolled yet.
+ *
+ * @type {number}
+ */
+export const DEFAULT_UNROLLED_DIE_VALUE = -1;

--- a/Frontend/src/Services/roll-manager/errors.js
+++ b/Frontend/src/Services/roll-manager/errors.js
@@ -1,0 +1,29 @@
+/**
+ * error class that models the RollManager data being invalid
+ */
+export class InvalidRollManagerDataError extends Error {}
+
+/**
+ * error class that models the Roll Manager settings being invalid
+ */
+export class InvalidRollManagerSettingsError extends Error {}
+
+/**
+ * error class that models the Roll Manager state being invalid
+ */
+export class InvalidRollManagerStateError extends Error {}
+
+/**
+ * error class for when we try to roll the dice and we have no rolls left allowed
+ */
+export class NoRollsLeftError extends Error {}
+
+/**
+ * error class for when we try to select/unselect a die that has never been rolled
+ */
+export class UnrolledDiceError extends Error {}
+
+/**
+ * error class for when we try to operate on a die that does not exist in the given Roll Manager data.
+ */
+export class UnknownDieError extends Error {}

--- a/Frontend/src/Services/roll-manager/private/test-utils.js
+++ b/Frontend/src/Services/roll-manager/private/test-utils.js
@@ -1,0 +1,374 @@
+import {
+  UnrolledDiceError,
+  InvalidRollManagerDataError,
+  InvalidRollManagerSettingsError,
+  InvalidRollManagerStateError,
+  UnknownDieError,
+} from "../errors";
+import { buildDieState } from "../creation";
+import { validateDieIndex } from "./validations";
+import { isValidRollManagerData } from "../queries";
+
+/**
+ * @type {RollManagerSettings}
+ */
+export const VALID_SETTINGS = {
+  numberOfDice: 6,
+  numberOfExtraDice: 2,
+  diceRollLimit: 3,
+};
+
+/**
+ * @type {DieState}
+ */
+export const DEFAULT_DIE_STATE = { isSelected: false, value: -1 };
+
+/**
+ * @type {DieState}
+ */
+export const ROLLED_DIE_STATE = { isSelected: false, value: 2 };
+
+/**
+ * @type {RollManagerState}
+ */
+export const VALID_STATE_UNROLLED = {
+  numberOfRolls: 0,
+  dice: [
+    { ...DEFAULT_DIE_STATE },
+    { ...DEFAULT_DIE_STATE },
+    { ...DEFAULT_DIE_STATE },
+    { ...DEFAULT_DIE_STATE },
+    { ...DEFAULT_DIE_STATE },
+    { ...DEFAULT_DIE_STATE },
+  ],
+};
+
+/**
+ * @type {RollManagerState}
+ */
+export const VALID_STATE_ROLLED = {
+  numberOfRolls: 1,
+  dice: [
+    { ...ROLLED_DIE_STATE },
+    { ...ROLLED_DIE_STATE },
+    { ...ROLLED_DIE_STATE },
+    { ...ROLLED_DIE_STATE },
+    { ...ROLLED_DIE_STATE },
+    { ...ROLLED_DIE_STATE },
+  ],
+};
+
+/**
+ * ensures that the given function will explode with invalid settings as arguments
+ * @param {Function} fn
+ */
+export function testValidatesSettings(fn) {
+  describe("validates settings", () => {
+    it("fails with `InvalidRollManagerSettingsError` passing null", () => {
+      expect(() => fn(null)).toThrow(InvalidRollManagerSettingsError);
+    });
+    it("fails with `InvalidRollManagerSettingsError` passing a string", () => {
+      expect(() => fn("cacafuti")).toThrow(InvalidRollManagerSettingsError);
+    });
+    it("fails with `InvalidRollManagerSettingsError` passing an array", () => {
+      expect(() => fn([])).toThrow(InvalidRollManagerSettingsError);
+    });
+    it("fails with `InvalidRollManagerSettingsError` passing an number", () => {
+      expect(() => fn(1)).toThrow(InvalidRollManagerSettingsError);
+    });
+    it("fails with `InvalidRollManagerSettingsError` passing {}", () => {
+      expect(() => fn({})).toThrow(InvalidRollManagerSettingsError);
+    });
+    it("fails with `InvalidRollManagerSettingsError` passing settings.numberOfDice with anything else than a number", () => {
+      const common = { numberOfExtraDice: 2, diceRollLimit: 3 };
+      expect(() => fn({ ...common })).toThrow(InvalidRollManagerSettingsError);
+      expect(() => fn({ ...common, numberOfDice: "1" })).toThrow(
+        InvalidRollManagerSettingsError
+      );
+      expect(() => fn({ ...common, numberOfDice: [1] })).toThrow(
+        InvalidRollManagerSettingsError
+      );
+      expect(() => fn({ ...common, numberOfDice: {} })).toThrow(
+        InvalidRollManagerSettingsError
+      );
+    });
+    it("fails with `InvalidRollManagerSettingsError` passing settings.numberOfExtraDice with anything else than a number", () => {
+      const common = { numberOfDice: 6, diceRollLimit: 3 };
+      expect(() => fn({ ...common })).toThrow(InvalidRollManagerSettingsError);
+      expect(() => fn({ ...common, numberOfExtraDice: "1" })).toThrow(
+        InvalidRollManagerSettingsError
+      );
+      expect(() => fn({ ...common, numberOfExtraDice: [1] })).toThrow(
+        InvalidRollManagerSettingsError
+      );
+      expect(() => fn({ ...common, numberOfExtraDice: {} })).toThrow(
+        InvalidRollManagerSettingsError
+      );
+    });
+    it("fails with `InvalidRollManagerSettingsError` passing settings.diceRollLimit with anything else than a number", () => {
+      const common = { numberOfDice: 6, numberOfExtraDice: 3 };
+      expect(() => fn({ ...common })).toThrow(InvalidRollManagerSettingsError);
+      expect(() => fn({ ...common, diceRollLimit: "1" })).toThrow(
+        InvalidRollManagerSettingsError
+      );
+      expect(() => fn({ ...common, diceRollLimit: [1] })).toThrow(
+        InvalidRollManagerSettingsError
+      );
+      expect(() => fn({ ...common, diceRollLimit: {} })).toThrow(
+        InvalidRollManagerSettingsError
+      );
+    });
+
+    // TODO "fails with the extra numeric limitations for allowed number of dice, allowed diceRollLimit, etc."
+
+    it("does not fail with valid settings", () => {
+      expect(() => fn(VALID_SETTINGS)).not.toThrow(
+        InvalidRollManagerSettingsError
+      );
+    });
+  });
+}
+
+/**
+ * ensures that the given function will explode with invalid state as arguments
+ * @param {Function} fn
+ */
+export function testValidatesState(fn) {
+  describe("validates state", () => {
+    it("fails with `InvalidRollManagerStateError` passing null", () => {
+      expect(() => fn(null)).toThrow(InvalidRollManagerStateError);
+    });
+    it("fails with `InvalidRollManagerStateError` passing a string", () => {
+      expect(() => fn("cacafuti")).toThrow(InvalidRollManagerStateError);
+    });
+    it("fails with `InvalidRollManagerStateError` passing an array", () => {
+      expect(() => fn([])).toThrow(InvalidRollManagerStateError);
+    });
+    it("fails with `InvalidRollManagerStateError` passing an number", () => {
+      expect(() => fn(1)).toThrow(InvalidRollManagerStateError);
+    });
+    it("fails with `InvalidRollManagerStateError` passing {}", () => {
+      expect(() => fn({})).toThrow(InvalidRollManagerStateError);
+    });
+    it("fails with `InvalidRollManagerStateError` passing state.numberOfRolls with anything else than a positive number", () => {
+      const common = { dice: VALID_STATE_UNROLLED.dice };
+      expect(() => fn({ ...common })).toThrow(InvalidRollManagerStateError);
+      expect(() => fn({ ...common, numberOfRolls: "1" })).toThrow(
+        InvalidRollManagerStateError
+      );
+      expect(() => fn({ ...common, numberOfRolls: [1] })).toThrow(
+        InvalidRollManagerStateError
+      );
+      expect(() => fn({ ...common, numberOfRolls: {} })).toThrow(
+        InvalidRollManagerStateError
+      );
+    });
+
+    it("fails with `InvalidRollManagerStateError` passing settings.dice with anything else than an array of die state objects with value -1", () => {
+      const common = { numberOfRolls: 1 };
+      expect(() => fn({ ...common })).toThrow(InvalidRollManagerStateError);
+      expect(() => fn({ ...common, dice: "1" })).toThrow(
+        InvalidRollManagerStateError
+      );
+      expect(() => fn({ ...common, dice: [1] })).toThrow(
+        InvalidRollManagerStateError
+      );
+      expect(() => fn({ ...common, dice: {} })).toThrow(
+        InvalidRollManagerStateError
+      );
+      expect(() => fn({ ...common, dice: [{}] })).toThrow(
+        InvalidRollManagerStateError
+      );
+    });
+
+    describe("with numberOfRolls=0", () => {
+      it("fails with `InvalidRollManagerStateError` passing settings.numberOfExtraDice with anything else than an array of die state objects with value -1", () => {
+        const common = { numberOfRolls: 0 };
+        const dice = [
+          DEFAULT_DIE_STATE,
+          ROLLED_DIE_STATE,
+          DEFAULT_DIE_STATE,
+          DEFAULT_DIE_STATE,
+          DEFAULT_DIE_STATE,
+          DEFAULT_DIE_STATE,
+        ];
+        expect(() => fn({ ...common, dice })).toThrow(
+          InvalidRollManagerStateError
+        );
+      });
+
+      it("is ok with all the dice in a non-rolled default state", () => {
+        const common = { numberOfRolls: 0 };
+        const dice = [
+          DEFAULT_DIE_STATE,
+          DEFAULT_DIE_STATE,
+          DEFAULT_DIE_STATE,
+          DEFAULT_DIE_STATE,
+          DEFAULT_DIE_STATE,
+          DEFAULT_DIE_STATE,
+        ];
+        expect(() => fn({ ...common, dice })).not.toThrow(
+          InvalidRollManagerStateError
+        );
+      });
+    });
+
+    describe("with numberOfRolls>0", () => {
+      it("fails with `InvalidRollManagerStateError` passing settings.numberOfExtraDice with anything else than an array of die state objects with value -1", () => {
+        const common = { numberOfRolls: 1 };
+        const dice = [
+          ROLLED_DIE_STATE,
+          DEFAULT_DIE_STATE,
+          ROLLED_DIE_STATE,
+          ROLLED_DIE_STATE,
+          ROLLED_DIE_STATE,
+        ];
+        expect(() => fn({ ...common, dice })).toThrow(
+          InvalidRollManagerStateError
+        );
+      });
+
+      it("is ok with all the dice in a rolled non-default state", () => {
+        const common = { numberOfRolls: 1 };
+        const dice = [
+          ROLLED_DIE_STATE,
+          ROLLED_DIE_STATE,
+          ROLLED_DIE_STATE,
+          ROLLED_DIE_STATE,
+          ROLLED_DIE_STATE,
+          ROLLED_DIE_STATE,
+        ];
+        expect(() => fn({ ...common, dice })).not.toThrow(
+          InvalidRollManagerStateError
+        );
+      });
+    });
+  });
+}
+
+export function testValidatesData(fn) {
+  describe("checks data", () => {
+    describe("check settings", () => {
+      testValidatesSettings((settings) => {
+        fn({
+          settings,
+          state: { ...VALID_STATE_UNROLLED },
+        });
+      });
+    });
+
+    describe("check state", () => {
+      testValidatesState((state) => {
+        fn({
+          settings: VALID_SETTINGS,
+          state,
+        });
+      });
+    });
+
+    describe("checks the number of dice is the right one according to the settings", () => {
+      const settings = { ...VALID_SETTINGS, numberOfDice: 6 };
+
+      it("ok with the right amount of dice", () => {
+        const state = {
+          numberOfRolls: 0,
+          dice: [
+            { ...DEFAULT_DIE_STATE },
+            { ...DEFAULT_DIE_STATE },
+            { ...DEFAULT_DIE_STATE },
+            { ...DEFAULT_DIE_STATE },
+            { ...DEFAULT_DIE_STATE },
+            { ...DEFAULT_DIE_STATE },
+          ],
+        };
+        expect(() => fn({ settings, state })).not.toThrow(
+          InvalidRollManagerDataError
+        );
+      });
+
+      it("returns false with more dice", () => {
+        const state = {
+          numberOfRolls: 0,
+          dice: [
+            { ...DEFAULT_DIE_STATE },
+            { ...DEFAULT_DIE_STATE },
+            { ...DEFAULT_DIE_STATE },
+            { ...DEFAULT_DIE_STATE },
+            { ...DEFAULT_DIE_STATE },
+            { ...DEFAULT_DIE_STATE },
+            { ...DEFAULT_DIE_STATE },
+            { ...DEFAULT_DIE_STATE },
+          ],
+        };
+        expect(() => fn({ settings, state })).toThrow(
+          InvalidRollManagerDataError
+        );
+      });
+
+      it("returns false with less dice", () => {
+        const state = {
+          numberOfRolls: 0,
+          dice: [{ ...DEFAULT_DIE_STATE }, { ...DEFAULT_DIE_STATE }],
+        };
+        expect(() => fn({ settings, state })).toThrow(
+          InvalidRollManagerDataError
+        );
+      });
+    });
+
+    it("checks that the number of rolls is not greater than the max in the settings", () => {
+      const settings = VALID_SETTINGS;
+      const state = {
+        ...VALID_STATE_ROLLED,
+        numberOfRolls: settings.diceRollLimit + 1,
+      };
+      expect(() => fn({ settings, state })).toThrow(
+        InvalidRollManagerDataError
+      );
+    });
+  });
+}
+
+export function testValidatesDieIndex(fn) {
+  describe("checks dice index", () => {
+    const data = { settings: VALID_SETTINGS, state: VALID_STATE_ROLLED };
+
+    it("explodes with index -1", () => {
+      expect(() => fn(data, -1)).toThrow(UnknownDieError);
+    });
+    it("explodes with index === number of dice", () => {
+      expect(() => fn(data, data.state.dice.length)).toThrow(UnknownDieError);
+    });
+    it("explodes with index > number of dice", () => {
+      expect(() => fn(data, data.state.dice.length + 1)).toThrow(
+        UnknownDieError
+      );
+    });
+
+    it("ok with index === 0", () => {
+      expect(() => fn(data, 0)).not.toThrow(UnknownDieError);
+    });
+
+    it("ok with index === number of dice -1", () => {
+      expect(() => fn(data, data.state.dice.length - 1)).not.toThrow(
+        UnknownDieError
+      );
+    });
+  });
+}
+
+export function testValidatesRolledDie(fn) {
+  describe("checks unrolled die", () => {
+    const data = { settings: VALID_SETTINGS, state: VALID_STATE_UNROLLED };
+
+    it("explodes with unrolled", () => {
+      const data = { settings: VALID_SETTINGS, state: VALID_STATE_UNROLLED };
+      expect(() => fn(data, 0)).toThrow(UnrolledDiceError);
+    });
+
+    it("ok with rolled", () => {
+      const data = { settings: VALID_SETTINGS, state: VALID_STATE_ROLLED };
+      expect(() => fn(data, 0)).not.toThrow(UnrolledDiceError);
+    });
+  });
+}

--- a/Frontend/src/Services/roll-manager/private/typedefs.js
+++ b/Frontend/src/Services/roll-manager/private/typedefs.js
@@ -1,0 +1,18 @@
+/**
+ * The data of the RollManager, a combination of settings + state
+ * @typedef {{ settings: RollManagerSettings, state: RollManagerState }} RollManagerData
+ */
+
+/**
+ * The settings of the RollManager
+ * @typedef {{ numberOfDice: number, numberOfExtraDice: number, diceRollLimit: number }} RollManagerSettings
+ */
+
+/**
+ * The state of the RollManager
+ * @typedef {{ numberOfRolls: number, dice: DieState[] }} RollManagerState
+ */
+
+/**
+ * @typedef {{ value: number, isSelected: boolean }} DieState
+ */

--- a/Frontend/src/Services/roll-manager/private/validations.js
+++ b/Frontend/src/Services/roll-manager/private/validations.js
@@ -1,0 +1,197 @@
+import { isBoolean, isPlainObject } from "lodash";
+import {
+  InvalidRollManagerDataError,
+  InvalidRollManagerSettingsError,
+  InvalidRollManagerStateError,
+  UnknownDieError,
+  UnrolledDiceError,
+} from "../errors";
+import {
+  isArrayOfPlainObjects,
+  isFiniteInteger,
+  isPositiveFiniteInteger,
+} from "../../../utils/is-types";
+import { DEFAULT_UNROLLED_DIE_VALUE } from "../creation";
+
+/**
+ * explodes if the given data is a invalid RollManagerData, with the right amount of dice in the state that the settings indicate
+ * @param {RollManagerData} data
+ * @throws {InvalidRollManagerStateError | InvalidRollManagerSettingsError | InvalidRollManagerDataError}
+ * @private
+ */
+export function validateRollManagerData(data) {
+  if (!isPlainObject(data)) {
+    throw new InvalidRollManagerDataError(
+      "The given param is not a plain object"
+    );
+  }
+
+  validateSettings(data.settings);
+  validateState(data.state);
+
+  if (data.state.dice.length !== data.settings.numberOfDice) {
+    throw new InvalidRollManagerDataError(
+      "The given state has a different length of dice than the required by the given settings"
+    );
+  }
+
+  if (data.state.numberOfRolls > data.settings.diceRollLimit) {
+    throw new InvalidRollManagerDataError(
+      "The given state has a more rolls than the allowed by the settings"
+    );
+  }
+}
+
+/**
+ * explodes with invalid settings
+ * @param {RollManagerSettings} settings
+ * @private
+ */
+export function validateSettings(settings) {
+  if (!isPlainObject(settings)) {
+    throw new InvalidRollManagerSettingsError(
+      "The given settings param is not a plain object"
+    );
+  }
+
+  validateSettingsNumber(settings.numberOfDice, "numberOfDice");
+  validateSettingsNumber(settings.numberOfExtraDice, "numberOfExtraDice");
+  validateSettingsNumber(settings.diceRollLimit, "diceRollLimit");
+
+  // TODO: validate the rest of the settings
+}
+
+/**
+ * explodes with invalid state
+ * @param {RollManagerState} state
+ * @private
+ */
+export function validateState(state) {
+  if (!isPlainObject(state)) {
+    throw new InvalidRollManagerStateError(
+      "The given state param is not a plain object"
+    );
+  }
+
+  if (!isPositiveFiniteInteger(state.numberOfRolls)) {
+    throw new InvalidRollManagerStateError(
+      "state.numberOfRolls is not a finite integer"
+    );
+  }
+
+  if (!isArrayOfPlainObjects(state.dice)) {
+    throw new InvalidRollManagerStateError(`${name} is not a finite integer`);
+  }
+
+  if (state.numberOfRolls > 0) {
+    state.dice.forEach((d, i) => validateDieRolled(d, i));
+  } else {
+    state.dice.forEach((d, i) => validateDieUnrolled(d, i));
+  }
+}
+
+/**
+ * explodes if the given index is not a valid die index for the given data
+ * @param {RollManagerData} data (it is assumed that it is already validated)
+ * @param {number} index
+ * @throws {UnknownDieError}
+ * @private
+ */
+export function validateDieIndex(data, index) {
+  if (!isPositiveFiniteInteger(index)) {
+    throw new UnknownDieError(
+      `the given index is not a positive finite integer ${index}`
+    );
+  }
+
+  if (index >= data.state.dice.length) {
+    throw new UnknownDieError(
+      `the given index is larger than the number of dice in the given data ${index}`
+    );
+  }
+}
+
+/**
+ * explodes if the given die has never been rolled
+ *
+ * @param {RollManagerData} data (it is assumed that it is already validated)
+ * @param {number} index (it is assumed that it is already validated)
+ * @throws {UnrolledDiceError}
+ */
+export function validateRolledDie(data, index) {
+  if (data.state.dice[index].value === DEFAULT_UNROLLED_DIE_VALUE) {
+    throw new UnrolledDiceError(
+      `the die in the given index has never been rolled ${index}`
+    );
+  }
+}
+
+/**
+ * explodes with an invalid DieState or with a the value of the default un-rolled value
+ * @param {DieState} die
+ * @param {number} index
+ */
+function validateDieRolled(die, index) {
+  validateDie(die, index);
+
+  if (die.value === DEFAULT_UNROLLED_DIE_VALUE) {
+    throw new InvalidRollManagerStateError(
+      `The given die is is unrolled, index: ${index}`
+    );
+  }
+}
+
+/**
+ * explodes with an invalid DieState or with a the value that is not the default un-rolled value
+ * @param {DieState} die
+ * @param {number} index
+ */
+function validateDieUnrolled(die, index) {
+  validateDie(die, index);
+
+  if (die.value !== DEFAULT_UNROLLED_DIE_VALUE) {
+    throw new InvalidRollManagerStateError(
+      `The given die is is rolled, index: ${index}`
+    );
+  }
+}
+
+/**
+ * explodes with an invalid DieState
+ * @param {DieState} die
+ * @param {number} index
+ */
+function validateDie(die, index) {
+  if (!isPlainObject(die)) {
+    throw new InvalidRollManagerStateError(
+      `The given die is not a plain object, index: ${index}`
+    );
+  }
+
+  if (!isBoolean(die.isSelected)) {
+    throw new InvalidRollManagerStateError(
+      `The given die does not have a boolean in 'isSelected', index: ${index}`
+    );
+  }
+
+  if (!isFiniteInteger(die.value)) {
+    throw new InvalidRollManagerStateError(
+      `The given die does not have a finite integer in 'value', index: ${index}`
+    );
+  }
+}
+
+// aux
+
+/**
+ * explodes if the given value is not a valid number
+ * @param {any} value
+ * @param {string} name
+ */
+function validateSettingsNumber(value, name) {
+  if (!isPositiveFiniteInteger(value)) {
+    throw new InvalidRollManagerSettingsError(
+      `${name} is not a finite integer`
+    );
+  }
+}

--- a/Frontend/src/Services/roll-manager/private/validations.spec.js
+++ b/Frontend/src/Services/roll-manager/private/validations.spec.js
@@ -1,0 +1,115 @@
+import {
+  validateDieIndex,
+  validateRolledDie,
+  validateRollManagerData,
+  validateSettings,
+  validateState,
+} from "./validations";
+import {
+  DEFAULT_DIE_STATE,
+  testValidatesData,
+  testValidatesDieIndex,
+  testValidatesSettings,
+  testValidatesState,
+  testValidatesRolledDie,
+  VALID_SETTINGS,
+  VALID_STATE_UNROLLED,
+} from "./test-utils";
+import {
+  InvalidRollManagerSettingsError,
+  InvalidRollManagerStateError,
+} from "../errors";
+import { isValidRollManagerData } from "../queries";
+
+describe("validateSettings(settings)", () => {
+  // we can share some specs code by extracting it into functions
+  testValidatesSettings((settings) => validateSettings(settings));
+});
+
+describe("validateState(state)", () => {
+  // we can share some specs code by extracting it into functions
+  testValidatesState((state) => validateState(state));
+});
+
+describe("validateRollManagerData(data)", () => {
+  // we can share some specs code by extracting it into functions
+  testValidatesData((data) => validateRollManagerData(data));
+});
+
+describe("validateDieIndex(data, index)", () => {
+  testValidatesDieIndex((data, index) => validateDieIndex(data, index));
+});
+
+describe("validateRolledDie(data, index)", () => {
+  testValidatesRolledDie((data, index) => validateRolledDie(data, index));
+});
+
+describe("isValidRollManagerData(data)", () => {
+  describe("check settings", () => {
+    testValidatesSettings((settings) => {
+      const res = isValidRollManagerData({
+        settings,
+        state: { ...VALID_STATE_UNROLLED },
+      });
+      if (!res) {
+        throw new InvalidRollManagerSettingsError("invalid");
+      }
+    });
+  });
+
+  describe("check state", () => {
+    testValidatesState((state) => {
+      const res = isValidRollManagerData({
+        settings: VALID_SETTINGS,
+        state,
+      });
+      if (!res) {
+        throw new InvalidRollManagerStateError("invalid");
+      }
+    });
+  });
+
+  describe("checks the number of dice is the right one according to the settings", () => {
+    const settings = { ...VALID_SETTINGS, numberOfDice: 6 };
+
+    it("ok with the right amount of dice", () => {
+      const state = {
+        numberOfRolls: 0,
+        dice: [
+          { ...DEFAULT_DIE_STATE },
+          { ...DEFAULT_DIE_STATE },
+          { ...DEFAULT_DIE_STATE },
+          { ...DEFAULT_DIE_STATE },
+          { ...DEFAULT_DIE_STATE },
+          { ...DEFAULT_DIE_STATE },
+        ],
+      };
+      expect(isValidRollManagerData({ settings, state })).toBeTruthy();
+    });
+
+    it("returns false with more dice", () => {
+      const state = {
+        numberOfRolls: 0,
+        dice: [
+          { ...DEFAULT_DIE_STATE },
+          { ...DEFAULT_DIE_STATE },
+          { ...DEFAULT_DIE_STATE },
+          { ...DEFAULT_DIE_STATE },
+          { ...DEFAULT_DIE_STATE },
+          { ...DEFAULT_DIE_STATE },
+          { ...DEFAULT_DIE_STATE },
+          { ...DEFAULT_DIE_STATE },
+        ],
+      };
+      expect(isValidRollManagerData({ settings, state })).toBeFalsy();
+    });
+
+    it("returns false with less dice", () => {
+      const state = {
+        numberOfRolls: 0,
+        dice: [{ ...DEFAULT_DIE_STATE }, { ...DEFAULT_DIE_STATE }],
+      };
+      expect(isValidRollManagerData({ settings, state })).toBeFalsy();
+    });
+  });
+});

--- a/Frontend/src/Services/roll-manager/queries.js
+++ b/Frontend/src/Services/roll-manager/queries.js
@@ -1,0 +1,39 @@
+import { validateRollManagerData } from "./private/validations";
+
+/**
+ * returns true if we haven't reached the limit of rolls allowed
+ *
+ * @param {RollManagerData} data
+ * @return {boolean}
+ * @throws {InvalidRollManagerDataError} if the data is invalid
+ */
+export function rollManagerHasRollsLeft(data) {
+  validateRollManagerData(data);
+  // TODO implement hasRollsLeft()
+}
+
+/**
+ * returns true if we have rolled the dice at least once
+ *
+ * @param {RollManagerData} data
+ * @return {boolean}
+ * @throws {InvalidRollManagerDataError} if the data is invalid
+ */
+export function rollManagerHasResults(data) {
+  validateRollManagerData(data);
+  // TODO implement hasResults()
+}
+
+/**
+ * returns false if the given data is a invalid RollManagerData, with the right amount of dice in the state that the settings indicate
+ * @param {RollManagerData} data
+ * @see {validateRollManagerData}
+ */
+export function isValidRollManagerData(data) {
+  try {
+    validateRollManagerData(data);
+    return true;
+  } catch (_e) {
+    return false;
+  }
+}

--- a/Frontend/src/utils/is-types.js
+++ b/Frontend/src/utils/is-types.js
@@ -1,0 +1,29 @@
+import { isArray, isInteger, isPlainObject } from "lodash";
+
+/**
+ * returns true if `x` is a finite Integer
+ * @param {any} x
+ * @return {boolean}
+ */
+export function isFiniteInteger(x) {
+  return isInteger(x) && isFinite(x);
+}
+
+/**
+ * returns true if `x` is a finite Integer and it is >= 0
+ * @param {any} x
+ * @return {boolean}
+ */
+export function isPositiveFiniteInteger(x) {
+  return isFiniteInteger(x) && x >= 0;
+}
+
+/**
+ * returns true if `x` is an array of PlainObject
+ * @param {any} x
+ * @return {boolean}
+ */
+export function isArrayOfPlainObjects(x) {
+  if (!x || !isArray(x)) return false;
+  return x.length > 0 ? isPlainObject(x[0]) : true;
+}


### PR DESCRIPTION
Here we have the skeleton of a new service Roll Manager, but this time it is based on independent functions instead of a class.

I've added the functions with the TODOs, and I've done already the tests and the validations so that you don't get distracted by all that jazz.

I've also added a test to `getRandom()` to show you how I am testing that we actually roll the dice :) 

I have added a README in the new roll-manager service folder that explains the intention and the structure of the service.

Also, since we don't have typescript, I am using JSDoc with types, which will allow us to have autocomplete and warnings in webstorm. I've added links to the relevant doc sites to explain how that works.

Don't worry too much about the implementation of the tests, just code the actual functions to make them pass. We can discuss how they are coded and what tricks I have used in these tests.

Good hunting!